### PR TITLE
Add tests for dm-writeboost

### DIFF
--- a/lib/dmtest/suites/writeboost.rb
+++ b/lib/dmtest/suites/writeboost.rb
@@ -1,0 +1,1 @@
+require 'dmtest/tests/writeboost/writeboost_tests'

--- a/lib/dmtest/tests/writeboost/writeboost_stack.rb
+++ b/lib/dmtest/tests/writeboost/writeboost_stack.rb
@@ -1,0 +1,80 @@
+require 'dmtest/utils'
+require 'dmtest/thinp-test'
+require 'dmtest/disk-units'
+require 'dmtest/test-utils'
+
+#----------------------------------------------------------------
+
+module DM
+  class WriteboostTarget < Target
+    def initialize(sector_count, cache_dev, origin_dev)
+      super('writeboost', sector_count, [cache_dev, origin_dev])
+    end
+
+    # writeboost doesn't need to implement post_remove_check
+  end
+end
+
+#----------------------------------------------------------------
+
+class WriteboostStack
+  include DiskUnits
+  include ThinpTestMixin
+  include Utils
+
+  attr_accessor :ssd, :origin, :cache, :opts
+
+  def initialize(dm, ssd_dev, spindle_dev, opts)
+    @dm = dm
+    @ssd_dev = ssd_dev
+    @spindle_dev = spindle_dev
+
+    @ssd = nil
+    @origin = nil
+    @cache = nil
+    @opts = opts
+
+    @tvm = TinyVolumeManager::VM.new
+    @tvm.add_allocation_volume(ssd_dev, 0, dev_size(ssd_dev))
+    @tvm.add_volume(linear_vol('ssd', cache_size))
+
+    @data_tvm = TinyVolumeManager::VM.new
+    @data_tvm.add_allocation_volume(spindle_dev, 0, dev_size(spindle_dev))
+    @data_tvm.add_volume(linear_vol('origin', origin_size))
+  end
+
+  def activate(&block)
+    with_devs(@tvm.table('ssd'),
+              @data_tvm.table('origin')) do |ssd, origin|
+
+      @ssd = ssd
+      @origin = origin
+
+      wipe_device(ssd, 1) if @opts.fetch(:format, true)
+
+      with_dev(cache_table) do |cache|
+        @cache = cache
+        ensure_elapsed_time(1, self, &block)
+      end
+    end
+  end
+
+  # not used yet
+  def type
+    @opts.fetch(:type, 0)
+  end
+
+  def cache_size
+    @opts.fetch(:cache_size, meg(3))
+  end
+
+  def origin_size
+    @opts.fetch(:data_size, dev_size(@spindle_dev))
+  end
+
+  def cache_table
+    Table.new(WriteboostTarget.new(origin_size, @ssd, @origin))
+  end
+end
+
+#----------------------------------------------------------------

--- a/lib/dmtest/tests/writeboost/writeboost_tests.rb
+++ b/lib/dmtest/tests/writeboost/writeboost_tests.rb
@@ -1,0 +1,64 @@
+require 'dmtest/config'
+require 'dmtest/git'
+require 'dmtest/log'
+require 'dmtest/utils'
+require 'dmtest/fs'
+require 'dmtest/tags'
+require 'dmtest/thinp-test'
+require 'dmtest/cache-status'
+require 'dmtest/disk-units'
+require 'dmtest/test-utils'
+require 'dmtest/tests/cache/fio_subvolume_scenario'
+require 'dmtest/tests/writeboost/writeboost_stack'
+
+require 'pp'
+
+#----------------------------------------------------------------
+
+class WriteboostTests < ThinpTestCase
+  include GitExtract
+  include Tags
+  include Utils
+  include DiskUnits
+  include FioSubVolumeScenario
+  extend TestUtils
+
+  def with_standard_cache(opts = Hash.new, &block)
+    stack = WriteboostStack.new(@dm, @metadata_dev, @data_dev, opts)
+    stack.activate do |stack|
+      block.call(stack.cache)
+    end
+  end
+
+  def test_fio_sub_volume
+    with_standard_cache(@dm, @metadata_dev, @data_dev,
+                        :cache_size => meg(256),
+                        :format => true,
+                        :data_size => gig(4)) do |cache|
+      wait = lambda {sleep(5)}
+      fio_sub_volume_scenario(cache, &wait)
+    end
+  end
+
+  def test_fio_cache
+    with_standard_cache(@dm, @metadata_dev, @data_dev,
+                        :cache_size => meg(512),
+                        :format => true,
+                        :data_size => gig(2)) do |cache|
+      do_fio(cache, :ext4)
+    end
+  end
+
+  def test_fio_database_funtime
+    with_standard_cache(@dm, @metadata_dev, @data_dev,
+                        :cache_size => meg(1024),
+                        :format => true,
+                        :data_size => gig(10)) do |cache|
+      do_fio(cache, :ext4,
+             :outfile => "../fio_writeboost.out",
+             :cfgfile => "../tests/cache/database-funtime.fio")
+    end
+  end
+end
+
+#----------------------------------------------------------------


### PR DESCRIPTION
Hi, Joe,
this is the initial commit of the testing plugin for dm-writeboost.
I am working under dmtest/tests/writeboost that is segregated from other codebase.
If I am not going the wrong direction please git-pull.

dm-writeboost is a caching driver like dm-cache, bcache and enhance-io.
This patch introduces the minimum stack and tests for writeboost driver.

Now,
`dmtest list --suite writeboost` shows

writeboost
  WriteboostTests
    fio_cache
    fio_database_funtime
    fio_sub_volume
