### PR TITLE
Fix path (fio config and the output file)

### DIFF
--- a/lib/dmtest/libdir.rb
+++ b/lib/dmtest/libdir.rb
@@ -15,3 +15,16 @@ module DMTest
     end
   end
 end
+
+module Utils
+  # Library Path
+  def LP(path)
+    DMTest::Utils.gem_libdir + "/" + path
+  end
+
+  # Absolute Path
+  ROOTDIR = Pathname.new(".").realpath.to_s
+  def AP(path)
+    ROOTDIR + "/" + path
+  end
+end

--- a/lib/dmtest/tests/cache/bcache_tests.rb
+++ b/lib/dmtest/tests/cache/bcache_tests.rb
@@ -117,8 +117,8 @@ class BcacheTests < ThinpTestCase
                             :data_size => gig(10))
     stack.activate do |cache|
       do_fio(cache, :ext4,
-             :outfile => "../fio_bcache.out",
-             :cfgfile => "../tests/cache/database-funtime.fio")
+             :outfile => AP("fio_bcache.out"),
+             :cfgfile => LP("tests/cache/database-funtime.fio"))
     end
   end
 

--- a/lib/dmtest/tests/cache/cache_tests.rb
+++ b/lib/dmtest/tests/cache/cache_tests.rb
@@ -94,8 +94,8 @@ class CacheTests < ThinpTestCase
                         :policy => Policy.new('mq')) do |cache|
       cache.message(0, "sequential_threshold 32768") # 16M
       do_fio(cache, :ext4,
-             :outfile => "../fio_dm_cache.out",
-             :cfgfile => "../tests/cache/database-funtime.fio")
+             :outfile => AP("fio_dm_cache.out"),
+             :cfgfile => LP("tests/cache/database-funtime.fio"))
     end
   end
 

--- a/lib/dmtest/tests/cache/fio_subvolume_scenario.rb
+++ b/lib/dmtest/tests/cache/fio_subvolume_scenario.rb
@@ -1,7 +1,9 @@
 module FioSubVolumeScenario
+  include Utils
+
   def do_fio(dev, fs_type, opts = Hash.new)
-    outfile = opts.fetch(:outfile, "../fio.out")
-    cfgfile = opts.fetch(:cfgfile, "../tests/cache/fio.config")
+    outfile = opts.fetch(:outfile, AP("fio.out"))
+    cfgfile = opts.fetch(:cfgfile, LP("tests/cache/fio.config"))
     fs = FS::file_system(fs_type, dev)
     fs.format
 
@@ -32,7 +34,7 @@ module FioSubVolumeScenario
     1.upto(subvolume_count) do |n|
       with_dev(tvm.table("linear_#{n}")) do |subvolume|
         report_time("fio across subvolume #{n}", STDERR) do
-          do_fio(subvolume, :ext4, :outfile => "../fio_#{n}.out")
+          do_fio(subvolume, :ext4, :outfile => AP("fio_#{n}.out"))
         end
 
         wait.call

--- a/lib/dmtest/tests/writeboost/writeboost_stack.rb
+++ b/lib/dmtest/tests/writeboost/writeboost_stack.rb
@@ -8,7 +8,8 @@ require 'dmtest/test-utils'
 module DM
   class WriteboostTarget < Target
     def initialize(sector_count, cache_dev, origin_dev)
-      super('writeboost', sector_count, [cache_dev, origin_dev])
+      args = [0, origin_dev, cache_dev]
+      super('writeboost', sector_count, *args)
     end
 
     # writeboost doesn't need to implement post_remove_check
@@ -57,6 +58,18 @@ class WriteboostStack
         ensure_elapsed_time(1, self, &block)
       end
     end
+  end
+
+  # FIXME copied from cache_stack
+  # move to prelude?
+  def ensure_elapsed_time(seconds, *args, &block)
+    t = Thread.new(seconds) do |seconds|
+      sleep seconds
+    end
+
+    block.call(*args)
+
+    t.join
   end
 
   # not used yet

--- a/lib/dmtest/tests/writeboost/writeboost_tests.rb
+++ b/lib/dmtest/tests/writeboost/writeboost_tests.rb
@@ -31,8 +31,7 @@ class WriteboostTests < ThinpTestCase
   end
 
   def test_fio_sub_volume
-    with_standard_cache(@dm, @metadata_dev, @data_dev,
-                        :cache_size => meg(256),
+    with_standard_cache(:cache_size => meg(256),
                         :format => true,
                         :data_size => gig(4)) do |cache|
       wait = lambda {sleep(5)}
@@ -41,8 +40,7 @@ class WriteboostTests < ThinpTestCase
   end
 
   def test_fio_cache
-    with_standard_cache(@dm, @metadata_dev, @data_dev,
-                        :cache_size => meg(512),
+    with_standard_cache(:cache_size => meg(512),
                         :format => true,
                         :data_size => gig(2)) do |cache|
       do_fio(cache, :ext4)
@@ -50,13 +48,12 @@ class WriteboostTests < ThinpTestCase
   end
 
   def test_fio_database_funtime
-    with_standard_cache(@dm, @metadata_dev, @data_dev,
-                        :cache_size => meg(1024),
+    with_standard_cache(:cache_size => meg(1024),
                         :format => true,
                         :data_size => gig(10)) do |cache|
       do_fio(cache, :ext4,
-             :outfile => "../fio_writeboost.out",
-             :cfgfile => "../tests/cache/database-funtime.fio")
+             :outfile => AP("fio_writeboost.out"),
+             :cfgfile => LP("tests/cache/database-funtime.fio"))
     end
   end
 end

--- a/lib/dmtest/utils.rb
+++ b/lib/dmtest/utils.rb
@@ -1,5 +1,6 @@
 require 'dmtest/process'
 require 'dmtest/math-utils'
+require 'dmtest/libdir'
 require 'tempfile'
 
 # A hodge podge of functions that should probably find a better home.


### PR DESCRIPTION
Add AP and LP in Utils module
which converts given path to Absolute (from the caller's initial
location) path and to lib/dmtest/${path} respectively.

Writeboost runs its three tests without failure now.
Also, fixed the things for dm-cache and bcache.

![screenshot 2013-11-23 22 50 16](https://f.cloud.github.com/assets/785824/1606529/619cd392-5449-11e3-8b91-ee79ae911ed6.png)
