### PR TITLE
[writeboost] Generate the same tests for each type

### DIFF
--- a/lib/dmtest/tests/writeboost/stack.rb
+++ b/lib/dmtest/tests/writeboost/stack.rb
@@ -17,6 +17,7 @@ end
 
 #----------------------------------------------------------------
 
+# template class for stacks
 class WriteboostStack
   include EnsureElapsed
   include DiskUnits
@@ -150,9 +151,19 @@ class WriteboostStack
       a
     end
   end
+end
 
+class WriteboostStackType0 < WriteboostStack
   def table
     essentials = [0, @backing_dev, @cache_dev]
+    args = Args.new(@opts)
+    Table.new(WriteboostTarget.new(backing_sz, essentials + args.to_a))
+  end
+end
+
+class WriteboostStackType1 < WriteboostStack
+  def table
+    essentials = [1, @backing_dev, @cache_dev, @plog_dev]
     args = Args.new(@opts)
     Table.new(WriteboostTarget.new(backing_sz, essentials + args.to_a))
   end

--- a/lib/dmtest/tests/writeboost/tests.rb
+++ b/lib/dmtest/tests/writeboost/tests.rb
@@ -24,8 +24,11 @@ class WriteboostTests < ThinpTestCase
   include FioSubVolumeScenario
   extend TestUtils
 
+  attr_accessor :stack_maker
+
   def test_fio_sub_volume
-    s = WriteboostStack.new(@dm, @data_dev, @metadata_dev);
+    return unless @stack_maker
+    s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
       s.cleanup_cache
       wait = lambda {sleep(5)}
@@ -34,7 +37,8 @@ class WriteboostTests < ThinpTestCase
   end
 
   def test_fio_cache
-    s = WriteboostStack.new(@dm, @data_dev, @metadata_dev);
+    return unless @stack_maker
+    s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
       s.cleanup_cache
       do_fio(s.wb, :ext4)
@@ -42,7 +46,8 @@ class WriteboostTests < ThinpTestCase
   end
 
   def test_fio_database_funtime
-    s = WriteboostStack.new(@dm, @data_dev, @metadata_dev);
+    return unless @stack_maker
+    s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
       s.cleanup_cache
       do_fio(s.wb, :ext4,
@@ -52,4 +57,17 @@ class WriteboostTests < ThinpTestCase
   end
 end
 
+class WriteboostTestsType0 < WriteboostTests
+  def setup
+    super
+    @stack_maker = WriteboostStackType0
+  end
+end
+
+class WriteboostTestsType1 < WriteboostTests
+  def setup
+    super
+    @stack_maker = WriteboostStackType1
+  end
+end
 #----------------------------------------------------------------


### PR DESCRIPTION
dm-writeboost has type.
- type 0: only RAM buffer
- type 1: type 0 + persistent logging

The tests can be shared thus generate the same tests for both tests.

Design outline:
- The only difference in the stack classes is the table method which is
  passed to the dmsetup create.
- Stack class is a factory. Test class only depends on the functionality
  of creating a stack.

More tests will be added to WriteboostTests

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com
