### PR TITLE
[writeboost] fix: where to clean up cache

### DIFF
--- a/lib/dmtest/tests/writeboost/stack.rb
+++ b/lib/dmtest/tests/writeboost/stack.rb
@@ -98,6 +98,7 @@ class WriteboostStack
 
   def activate(force, &block)
     activate_support_devs do
+      cleanup_cache
       activate_top_level(force, &block)
     end
   end

--- a/lib/dmtest/tests/writeboost/tests.rb
+++ b/lib/dmtest/tests/writeboost/tests.rb
@@ -51,7 +51,6 @@ module WriteboostTests
   def test_fio_sub_volume
     s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
-      s.cleanup_cache
       wait = lambda {sleep(5)}
       fio_sub_volume_scenario(s.wb, &wait)
     end
@@ -60,7 +59,6 @@ module WriteboostTests
   def test_fio_cache
     s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
-      s.cleanup_cache
       do_fio(s.wb, :ext4)
     end
   end
@@ -68,7 +66,6 @@ module WriteboostTests
   def test_fio_database_funtime
     s = @stack_maker.new(@dm, @data_dev, @metadata_dev);
     s.activate(true) do
-      s.cleanup_cache
       do_fio(s.wb, :ext4,
              :outfile => AP("fio_writeboost.out"),
              :cfgfile => LP("tests/cache/database-funtime.fio"))


### PR DESCRIPTION
activate() first activates the underlying devices and then activates the
wb device with them.
cleanup_cache (zeros out the superblock) needs to be called right after
the first activation, which is of underlying devices. not the second
one.

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com
