### PR TITLE
[writeboost] Remove term migrate

### DIFF
--- a/lib/dmtest/tests/writeboost/stack.rb
+++ b/lib/dmtest/tests/writeboost/stack.rb
@@ -121,10 +121,10 @@ class WriteboostStack
                  :nr_rambuf_pool,
     ]
     TUNABLES = [:barrier_deadline_ms,
-                :allow_migrate,
-                :enable_migration_modulator,
-                :migrate_threshold,
-                :nr_max_batched_migration,
+                :allow_writeback,
+                :enable_writeback_modulator,
+                :writeback_threshold,
+                :nr_max_batched_writeback,
                 :update_record_interval,
                 :sync_interval,
     ]

--- a/lib/dmtest/tests/writeboost/status.rb
+++ b/lib/dmtest/tests/writeboost/status.rb
@@ -7,10 +7,10 @@ class WriteboostStatus
   end
 
   TUNABLES = ["barrier_deadline_ms",
-              "allow_migrate",
-              "enable_migration_modulator",
-              "migrate_threshold",
-              "nr_max_batched_migration",
+              "allow_writeback",
+              "enable_writeback_modulator",
+              "writeback_threshold",
+              "nr_max_batched_writeback",
               "update_record_interval",
               "sync_interval"]
 
@@ -55,7 +55,7 @@ class WriteboostStatus
   private
   def parse(output)
     arr = output.split.reverse
-    before_stat = ["cursor_pos", "nr_cache_blocks", "nr_segments", "current_id", "last_flushed_id", "last_migrated_id", "nr_dirty_cache_blocks"]
+    before_stat = ["cursor_pos", "nr_cache_blocks", "nr_segments", "current_id", "last_flushed_id", "last_writeback_id", "nr_dirty_cache_blocks"]
 
     before_stat.size.times do |i|
       v = arr.pop(1).first.to_i
@@ -86,15 +86,9 @@ end
 
 if __FILE__ == $0
   x = (1..24).to_a
-  names = ["barrier_deadline_ms",
-           "allow_migrate",
-           "enable_migration_modulator",
-           "migrate_threshold",
-           "nr_max_batched_migration",
-           "update_record_interval",
-           "sync_interval"]
+
   y = (25..31).to_a
-  _output = x + [14] + names.zip(y).flatten
+  _output = x + [14] + WriteboostStatus::TUNABLES.zip(y).flatten
   output = _output.join(" ")
   # p output
 


### PR DESCRIPTION
Now writeboost uses two terms "migrate" and "writeback" to
represent writeback. The term "writeback" is more intuitive so
we don't use the term "migrate" anymore.

This is a patch that must be merged atomically with
one to the kernel.

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com

---

This is a counterpart of the pull request to your linux-2.6.
