### PR TITLE
[writeboost] Remove barrier_deadline_ms

### DIFF
--- a/lib/dmtest/tests/writeboost/stack.rb
+++ b/lib/dmtest/tests/writeboost/stack.rb
@@ -120,8 +120,7 @@ class WriteboostStack
     OPTIONALS = [:segment_size_order,
                  :nr_rambuf_pool,
     ]
-    TUNABLES = [:barrier_deadline_ms,
-                :allow_writeback,
+    TUNABLES = [:allow_writeback,
                 :enable_writeback_modulator,
                 :writeback_threshold,
                 :nr_max_batched_writeback,

--- a/lib/dmtest/tests/writeboost/status.rb
+++ b/lib/dmtest/tests/writeboost/status.rb
@@ -6,8 +6,7 @@ class WriteboostStatus
     WriteboostStatus.new m[1]
   end
 
-  TUNABLES = ["barrier_deadline_ms",
-              "allow_writeback",
+  TUNABLES = ["allow_writeback",
               "enable_writeback_modulator",
               "writeback_threshold",
               "nr_max_batched_writeback",
@@ -87,8 +86,8 @@ end
 if __FILE__ == $0
   x = (1..24).to_a
 
-  y = (25..31).to_a
-  _output = x + [14] + WriteboostStatus::TUNABLES.zip(y).flatten
+  y = (25..30).to_a
+  _output = x + [12] + WriteboostStatus::TUNABLES.zip(y).flatten
   output = _output.join(" ")
   # p output
 


### PR DESCRIPTION
In writeboost, Processing of write barriers is deferred.

Now there are two stages, 1) tunable deferment by timer which
queues a work and then 2) the work is dispatched.

This patch removes the first stage.

dm-thin and dm-cache do almost the same thing but they don't have such
complicated mechanism but only the second stage.
As a result of having the first stage, the code is complicated and hard
to understand, and also complicates the user interface.
I think of removing of this tunable for this reason.

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com
