### PR TITLE
fix issue #65 - run_fio wrong number of arguments

### DIFF
--- a/lib/dmtest/tests/cache/fio_tests.rb
+++ b/lib/dmtest/tests/cache/fio_tests.rb
@@ -147,7 +147,7 @@ EOF
     vg.add_allocation_volume(dev)
     vg.add_volume(linear_vol("vol", sub_vol_size))
     with_dev(vg.table("vol")) do |vol|
-      run_fio(vol, name)
+      run_fio(vol, name, gig(1))
     end
   end
 


### PR DESCRIPTION
Error:test_fio_on_fast(FIOTests):
ArgumentError: wrong number of arguments (given 2, expected 3)
/root/device-mapper-test-suite/lib/dmtest/tests/cache/fio_tests.rb:85:in `run_fio'