### PR TITLE
fix issue #67 - undefined method wait_for_all_clean

### DIFF
--- a/lib/dmtest/tests/cache/smq_tests.rb
+++ b/lib/dmtest/tests/cache/smq_tests.rb
@@ -9,6 +9,7 @@ require 'dmtest/test-utils'
 require 'dmtest/tvm.rb'
 require 'dmtest/cache_stack'
 require 'dmtest/cache_policy'
+require 'dmtest/cache_utils'
 require 'dmtest/tests/cache/fio_subvolume_scenario'
 require 'dmtest/fio-benchmark'
 require 'dmtest/tests/cache/pool_cache_stack'
@@ -23,6 +24,7 @@ class SMQComparisonTests < ThinpTestCase
   include Utils
   include DiskUnits
   include FioSubVolumeScenario
+  include CacheUtils
   extend TestUtils
 
   POLICY_NAMES = %w(mq)


### PR DESCRIPTION
Error:test_fio_sub_volume(SMQComparisonTests):
NoMethodError: undefined method wait_for_all_clean' for # /usr/local/rvm/gems/ruby-2.5.3/gems/rspec-expectations-2.14.5/lib/rspec/matchers/method_missing.rb:9:in method_missing'
/root/device-mapper-test-suite/lib/dmtest/tests/cache/smq_tests.rb:120:in block (3 levels) in ' /root/device-mapper-test-suite/lib/dmtest/tests/cache/fio_subvolume_scenario.rb:40:in block (2 levels) in fio_sub_volume_scenario'
/root/device-mapper-test-suite/lib/dmtest/ensure_elapsed.rb:13:in ensure_elapsed_time' /root/device-mapper-test-suite/lib/dmtest/device-mapper/lexical_operators.rb:15:in block in with_dev'
...