### PR TITLE
fix issue #71 ArgumentError: incomplete format specifier

### DIFF
--- a/lib/dmtest/blktrace.rb
+++ b/lib/dmtest/blktrace.rb
@@ -212,7 +212,7 @@ module BlkTrace
       iod = @cpu_iod.map do |s|
         s *= 512
         size = Filesize.from("#{s} B").pretty
-        percent = sprintf("%.2f%", total > 0 ? (s * 100.0 / total) : 0)
+        percent = sprintf("%.2f%%", total > 0 ? (s * 100.0 / total) : 0)
 
         "#{size} (#{percent})"
       end


### PR DESCRIPTION
test_fio_origin_randwrite_iod_N(FIOTests):
ArgumentError: incomplete format specifier; use %% (double %) instead
    /root/device-mapper-test-suite/lib/dmtest/blktrace.rb:215:in `sprintf'